### PR TITLE
Change powerline "New Point" to create at cursor.

### DIFF
--- a/src/no_mans_sky_base_builder/__init__.py
+++ b/src/no_mans_sky_base_builder/__init__.py
@@ -1365,7 +1365,7 @@ class Point(bpy.types.Operator):
         selection = blend_utils.get_current_selection()
 
         # Don't stack multiple for multiple clicks
-        if context.scene.cursor.location == selection.location:
+        if selection and context.scene.cursor.location == selection.location:
             return {"CANCELLED"}
 
         # Create a new point at the cursor.


### PR DESCRIPTION
Previously created at origin or selection +(1,1,0). Creating at cursor seems more blender-idiomatic, and simplifies routing workflow.

Also prevents multi-click of create from stacking powerline control points.