### PR TITLE
divide: Fix subdividing first segment of divided powerline

### DIFF
--- a/src/no_mans_sky_base_builder/__init__.py
+++ b/src/no_mans_sky_base_builder/__init__.py
@@ -1452,7 +1452,7 @@ class Divide(bpy.types.Operator):
         
         # Validate
         invalid_message = "Make sure you have a powerline item selected."
-        title = "Split"
+        title = "Divide"
         if not target:
             ShowMessageBox(message=invalid_message, title=title)
             return {"FINISHED"}

--- a/src/no_mans_sky_base_builder/part_overrides/line.py
+++ b/src/no_mans_sky_base_builder/part_overrides/line.py
@@ -228,8 +228,14 @@ class Line(no_mans_sky_base_builder.part.Part):
         point["rig_item"] = True
         point["SnapID"] = "POWER_CONTROL"
 
-        if name == default_name:
-            name = "{}.{}".format(name, point.name.split(".")[-1])
+        # blender will automatically de-dupe on rename, but it will rename
+        # some *other* object, whose name we might already have stored as text.
+        # (Also have to account for it having already given us a good name)
+        n = 0
+        base_name = name
+        while point.name != name and (name == default_name or blend_utils.item_exists_by_name(name)):
+            n += 1
+            name = "{}.{:0=3d}".format(base_name, n)
 
         point.name = name
         point.data.name = name+"_SHAPE"

--- a/src/no_mans_sky_base_builder/utils/blend_utils.py
+++ b/src/no_mans_sky_base_builder/utils/blend_utils.py
@@ -45,6 +45,16 @@ def get_item_by_name(item_name):
     """
     return bpy.data.objects[item_name]
 
+def item_exists_by_name(item_name):
+    """Check for a Blender object by specifying the name of the object.
+    
+    Args:
+        item_name (str): The name of the item.
+        
+    Returns:
+        bool: True iff object exists.    
+    """
+    return item_name in bpy.data.objects
 
 def remove_object(name):
     """Remove an item from the scene by specifying it's name.


### PR DESCRIPTION
Fixes create_point inadvertently renaming an existing object in order to give the caller their desired name.

Code would re-use the _MID name, and the Blender name de-dupe behavior steals that name from an existing object (renaming some other object to have a number suffix). Since we save object names as text, this causes bugs with the existing segments having incorrect references. Most noticeable is the second half of the subdivided segment not getting created (because we look up the saved _MID name by name and get the new midpoint we just created instead of end of this segment which was previously generated with the same name).