### PR TITLE
Improvements to connect, add power-related selection ops

### DIFF
--- a/src/no_mans_sky_base_builder/__init__.py
+++ b/src/no_mans_sky_base_builder/__init__.py
@@ -1401,44 +1401,56 @@ class Connect(bpy.types.Operator):
 
     def execute(self, context):
         # Validate selection.
-        selected_objects = bpy.context.selected_objects
-        if len(selected_objects) != 2:
+        selected_objects = [BUILDER.get_builder_object_from_bpy_object(o) for o in bpy.context.selected_objects]
+        selected_objects = [o for o in selected_objects if o.has_snap_point("POWER")]
+        if len(selected_objects) < 2:
             message = (
-                "Make sure you have two electric points selected."
+                "Make sure you have two or more electric points selected."
             )
             ShowMessageBox(message=message, title="Connect")
             return {"FINISHED"}
 
-        # Build and perform connection .
-        start = selected_objects[0]
-        end = selected_objects[1]
-
-        start = BUILDER.get_builder_object_from_bpy_object(start)
-        end = BUILDER.get_builder_object_from_bpy_object(end)
-        # Validate points.
-        start, end = line.Line.generate_control_points(start, end, BUILDER)
-        if not start and not end:
+        # Test this after selection for better error reporting
+        if not bpy.context.active_object:
             message = (
-                "These two items are not compatible to connect."
+                "Make sure one object is the active object (shift select the object to connect everything to)."
             )
             ShowMessageBox(message=message, title="Connect")
             return {"FINISHED"}
 
-        start_name = start.name
-        end_name = end.name
-        # Re-obtain objects
-        start = blend_utils.get_item_by_name(start_name)
-        end = blend_utils.get_item_by_name(end_name)
-        # Create new power line.
-        line_object = "U_POWERLINE"
-        if "power_line" in start:
-            line_object = start["power_line"].split(".")[0]
-        power_line = BUILDER.add_part(line_object, build_rigs=False)
-        # Create controls.
-        power_line.build_rig(
-            start=start,
-            end=end
-        )
+        start = BUILDER.get_builder_object_from_bpy_object(bpy.context.active_object)
+        if not start.has_snap_point("POWER"):
+            message = (
+                "Make sure the active object supports electrical connections."
+            )
+            ShowMessageBox(message=message, title="Connect")
+            return {"FINISHED"}
+
+        for end in selected_objects:
+            if end == start:
+                continue
+
+            # Build and perform connection.
+            start_point, end_point = line.Line.generate_control_points(start, end, BUILDER)
+            if not start_point or not end_point:
+                # should have been tested by filtering selected_objects above
+                continue
+
+            # Re-obtain objects
+            start_point = blend_utils.get_item_by_name(start_point.name)
+            end_point = blend_utils.get_item_by_name(end_point.name)
+
+            # Create new power line.
+            line_object = "U_POWERLINE"
+            if "power_line" in start_point:
+                line_object = start_point["power_line"].split(".")[0]
+            power_line = BUILDER.add_part(line_object, build_rigs=False)
+            # Create controls.
+            power_line.build_rig(
+                start=start_point,
+                end=end_point
+            )
+
         return {"FINISHED"}
 
 class Divide(bpy.types.Operator):

--- a/src/no_mans_sky_base_builder/builder.py
+++ b/src/no_mans_sky_base_builder/builder.py
@@ -166,7 +166,7 @@ class Builder(object):
         # If all fails, return None.
         return None
 
-    def get_all_parts(self, exclude_presets=False, skip_object_type=None):
+    def get_all_parts(self, exclude_presets=False, skip_object_type=None, include_lines=False):
         """Get all NMS parts in the scene.
 
         Args:
@@ -179,6 +179,10 @@ class Builder(object):
         # Get all individual NMS parts.
         flat_parts = [part for part in bpy.data.objects if "ObjectID" in part]
         flat_parts = [part for part in flat_parts if part["ObjectID"] not in skip_object_type]
+
+        # Include line conatrol points?
+        if include_lines:
+            flat_parts.extend([part for part in bpy.data.objects if "SnapID" in part and not "ObjectID" in part])
 
         # If exclude presets is on, just return the top level objects.
         if exclude_presets:

--- a/src/no_mans_sky_base_builder/part.py
+++ b/src/no_mans_sky_base_builder/part.py
@@ -704,3 +704,13 @@ class Part(object):
             return None
         # Return matrix.
         return snap_matrices[key]["matrix"]
+
+    def has_snap_point(self, filter=None):
+        """Check for any matrix that would match the given filter."""
+        # Get relavant snap information from item.
+        snap_matrices = self.get_snap_points()
+        # Validate key entry.
+        for key, info in snap_matrices.items():
+            if not filter or filter in key:
+                return True
+        return False

--- a/src/no_mans_sky_base_builder/part.py
+++ b/src/no_mans_sky_base_builder/part.py
@@ -714,3 +714,50 @@ class Part(object):
             if not filter or filter in key:
                 return True
         return False
+
+    def get_connected_snapped_objects(self, filter=None, include_lines=True):
+        """Get all objects connected to the given snap category.
+        
+        Args:
+            filter (str): A filter for the snap points being used.
+        """
+        source_matrices = self.get_snap_points()
+        if filter is not None:
+            source_matrices = { k: v for k, v in source_matrices.items() if filter in k }
+
+        source_points = [self.matrix_world @ mathutils.Matrix(info["matrix"]) for k, info in source_matrices.items()]
+
+        result = []
+        if not source_points:
+            return result
+
+        for target in self.builder.get_all_parts(include_lines=include_lines):
+            if target == self.object:
+                continue
+
+            target = self.builder.get_builder_object_from_bpy_object(target)
+            snap_points = target.get_snap_points()
+            if not snap_points:
+                continue
+            for target_key, target_info in snap_points.items():
+                # Check target filter.
+                if filter and filter not in target_key:
+                    continue
+                
+                local_target_matrix = mathutils.Matrix(target_info["matrix"])
+                target_snap_matrix = target.matrix_world @ local_target_matrix
+
+                found = False
+                for source_snap_matrix in source_points:
+                    distance = blend_utils.get_distance_between(
+                        source_snap_matrix, target_snap_matrix
+                    )
+                    if distance < 0.050:  # XXX what is actual game threshold?
+                        found = True
+                        break
+                if found:
+                    result.append(target)
+                    break
+
+        return result
+

--- a/src/no_mans_sky_base_builder/part_overrides/line.py
+++ b/src/no_mans_sky_base_builder/part_overrides/line.py
@@ -47,6 +47,15 @@ class Line(no_mans_sky_base_builder.part.Part):
     def end_control(self, value):
         self.object["end_control"] = value
 
+    # snap points are in the object's world space, so they are constant:
+    __snap_points = {
+        "POWER_A": { "matrix": mathutils.Matrix() },
+        "POWER_B": { "matrix": mathutils.Matrix.Translation([0, 0, 1]) }
+    }
+    def get_snap_points(self):
+        """Override base class for lines with synthetic snap points at each end."""
+        return self.__snap_points
+
     def build_rig(self, start=None, end=None):
         """Given the power line object, create 2 empties to control end points.
 


### PR DESCRIPTION
The connect operator now connects all selected objects to the active selected object (two object selection works as before).

Adds two new operators, one which selects anything with a POWER* snap connection to the existing selected objects, and one which selects anything floating (disconnected).

The "select connected" button is super useful for moving objects together with their hard-to-select power line handles.

(Connect all was necessary for the base I just made with 250ish floor lights!)

(Sorry not to split these up, but I'm probably done building bases for a while and I didn't want to lose track of these diffs)